### PR TITLE
Disable webpack AMD parser for chess.js, instantiate game lazily

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2575,11 +2575,6 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
-    "browser-or-node": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-1.2.1.tgz",
-      "integrity": "sha512-sVIA0cysIED0nbmNOm7sZzKfgN1rpFmrqvLZaFWspaBAftfQcezlC81G6j6U2RJf4Lh66zFxrCeOsvkUXIcPWg=="
-    },
     "browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "webpack-cli": "^3.3.11"
   },
   "dependencies": {
-    "browser-or-node": "^1.2.1",
     "chess.js": "^0.10.3"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chess.js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "React hooks for the chess.js library",
   "main": "dist/react-chess.js",
   "scripts": {

--- a/src/useChess.js
+++ b/src/useChess.js
@@ -1,14 +1,31 @@
-import { useCallback, useReducer, useRef } from 'react';
+import { useCallback, useEffect, useReducer, useRef } from 'react';
 import { Chess } from 'chess.js';
 
 const useChess = ({ onLegalMove, onIllegalMove, onGameOver } = {}) => {
-    const game = useRef(new Chess());
+    const game = useRef(null);
 
-    const initialState = {
-        history: game.current.history(),
-        fen: game.current.fen(),
-        turn: game.current.turn()
+    // Lazily instantiate Chess object only once
+    const getGame = () => {
+        if (game.current === null) {
+            game.current = new Chess();
+        }
+
+        return game.current;
     };
+
+    // Clean up Chess object on unmount
+    useEffect(() => {
+        return () => {
+            if (game.current) game.current.destroy();
+        };
+    }, [game]);
+
+    // Lazily instantiate initial state
+    const getInitialState = () => ({
+        history: getGame().history(),
+        fen: getGame().fen(),
+        turn: getGame().turn()
+    });
 
     // Used to update the values of props after every function that mutates the
     // Chess object state
@@ -16,23 +33,23 @@ const useChess = ({ onLegalMove, onIllegalMove, onGameOver } = {}) => {
         switch (action.type) {
             case 'update':
                 return {
-                    history: game.current.history(),
-                    fen: game.current.fen(),
-                    turn: game.current.turn()
+                    history: getGame().history(),
+                    fen: getGame().fen(),
+                    turn: getGame().turn()
                 };
             default:
                 throw new Error(`Unknown action type: ${action.type}`);
         }
     }, [game]);
 
-    const [state, dispatch] = useReducer(reducer, initialState);
+    const [state, dispatch] = useReducer(reducer, undefined, getInitialState);
 
     const makeMove = useCallback((move) => {
-        if (game.current.move(move)) {
+        if (getGame().move(move)) {
             dispatch({ type: 'update' });
 
             if (onLegalMove) onLegalMove(move);
-            if (game.current.game_over() && onGameOver) onGameOver();
+            if (getGame().game_over() && onGameOver) onGameOver();
 
             return;
         }
@@ -42,12 +59,12 @@ const useChess = ({ onLegalMove, onIllegalMove, onGameOver } = {}) => {
     }, [game, onLegalMove, onIllegalMove, onGameOver]);
 
     const reset = useCallback(() => {
-        game.current.reset();
+        getGame().reset();
         dispatch({ type: 'update' });
     }, [game]);
 
     const undo = useCallback(() => {
-        game.current.undo();
+        getGame().undo();
         dispatch({ type: 'update' });
     }, [game]);
 

--- a/src/useChess.js
+++ b/src/useChess.js
@@ -1,24 +1,5 @@
 import { useCallback, useReducer, useRef } from 'react';
-import { isNode } from 'browser-or-node';
-
-let Chess;
-
-/**
- * In CommonJS environments, chess.js exports an object with the Chess
- * constructor as a property, while on AMD environments it exports the Chess
- * constructor directly. Webpack supports both CommonJS and AMD. Due to an issue
- * in chess.js (https://github.com/jhlywa/chess.js/issues/196), you get the AMD
- * export with Webpack, so tests running in Node and code bundled with Webpack
- * cannot both use the same import signature. The following is a temporary
- * workaround until the issue in chess.js is resolved.
- */
-if (isNode) {
-    const chess = require('chess.js');
-    Chess = chess.Chess;
-}
-else {
-    Chess = require('chess.js');
-}
+import { Chess } from 'chess.js';
 
 const useChess = ({ onLegalMove, onIllegalMove, onGameOver } = {}) => {
     const game = useRef(new Chess());

--- a/src/useChess.spec.js
+++ b/src/useChess.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { expect } from 'chai';
 import { Chess } from 'chess.js';
 
@@ -49,7 +49,7 @@ describe('useChess', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-        wrapper = shallow(<App />);
+        wrapper = mount(<App />);
     });
 
     describe('initial props', () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,12 @@ module.exports = {
                         babelrc: true
                     }
                 }
+            },
+            {
+                test: require.resolve('chess.js'),
+                parser: {
+                    amd: false
+                }
             }
         ]
     }


### PR DESCRIPTION
1. Disable webpack AMD parser for chess.js so environment detection is no longer needed
2. Lazily instantiate game and clean up on unmount to avoid memory leaks and avoid creating a new Chess object on every render