### PR TITLE
Call onLegalMove with full move including check or checkmate indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,15 +103,14 @@ argument: the move that was made, expressed in standard algebraic notation
 If the move puts the other player in check or checkmate, `move` will include '+'
 or '#', even if it was not included when the move was made. For example:
 
-    const { move } = useChess({
-        onLegalMove: moveMade => console.log(moveMade)
-    });
+    const handleLegalMove = moveMade => console.log(moveMade);
+    const { move } = useChess({ onLegalMove: handleLegalMove });
 
     move('e4');
     move('e5');
     move('Qf3');
     move('Nc6');
-    move('Qxf7'); // calls onLegalMove('Qxf7+')
+    move('Qxf7'); // calls handleLegalMove('Qxf7+')
 
 #### onIllegalMove
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ Called after a legal move has been made. The function is called with one
 argument: the move that was made, expressed in standard algebraic notation
 (e.g. 'Nf3').
 
+If the move puts the other player in check or checkmate, `move` will include '+'
+or '#', even if it was not included when the move was made. For example:
+
+    const { move } = useChess({
+        onLegalMove: moveMade => console.log(moveMade)
+    });
+
+    move('e4');
+    move('e5');
+    move('Qf3');
+    move('Nc6');
+    move('Qxf7'); // calls onLegalMove('Qxf7+')
+
 #### onIllegalMove
 
 `function(move)` _optional_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chess.js",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "React hooks for the chess.js library",
   "main": "dist/react-chess.js",
   "files": ["dist/"],

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.0",
   "description": "React hooks for the chess.js library",
   "main": "dist/react-chess.js",
+  "files": ["dist/"],
   "scripts": {
     "test": "jest",
     "test:watch": "npm test -- --watch",

--- a/src/useChess.js
+++ b/src/useChess.js
@@ -86,9 +86,9 @@ const useChess = (props) => {
     const [state, dispatch] = useReducer(reducer, undefined, getInitialState);
 
     const makeMove = useCallback((move) => {
-        let moveMade;
+        const moveMade = getGame().move(move);
 
-        if (moveMade = getGame().move(move)) {
+        if (moveMade) {
             dispatch({ type: 'update' });
 
             if (props.onLegalMove) props.onLegalMove(moveMade.san);

--- a/src/useChess.js
+++ b/src/useChess.js
@@ -86,10 +86,12 @@ const useChess = (props) => {
     const [state, dispatch] = useReducer(reducer, undefined, getInitialState);
 
     const makeMove = useCallback((move) => {
-        if (getGame().move(move)) {
+        let moveMade;
+
+        if (moveMade = getGame().move(move)) {
             dispatch({ type: 'update' });
 
-            if (props.onLegalMove) props.onLegalMove(move);
+            if (props.onLegalMove) props.onLegalMove(moveMade.san);
 
             // Call handlers for check, checkmate, draw, stalemate, etc.
             for (const [handler, method] of Object.entries(legalMoveEffects)) {

--- a/src/useChess.spec.js
+++ b/src/useChess.spec.js
@@ -123,7 +123,7 @@ describe('useChess', () => {
     describe('move', () => {
 
         beforeEach(() => {
-            mockMove.mockReturnValue(true);
+            mockMove.mockImplementation(move => ({ san: move }));
             mockHistory.mockReturnValue([]);
             mockGameOver.mockReturnValue(false);
             mockCheck.mockReturnValue(false);
@@ -135,13 +135,15 @@ describe('useChess', () => {
         });
 
         it('should call onLegalMove after a legal move is made', () => {
+            mockMove.mockReturnValue({ san: 'e4+' });
+
             act(() => {
                 wrapper.find(TestComponent).props().move('e4');
             });
 
             wrapper.update();
 
-            expect(mockOnLegalMove).to.have.beenCalledWith('e4');
+            expect(mockOnLegalMove).to.have.beenCalledWith('e4+');
             expect(mockOnIllegalMove).to.not.have.beenCalled();
         });
 


### PR DESCRIPTION
Previously, the `onLegalMove` handler was called with the exact same move text as was passed to the `move` function. Now, append the check or checkmate indicator `+` or `#'` to the move if it resulted in check or checkmate.